### PR TITLE
[REFACTOR] 송신자 PeerConnection 로직 함수로 분리하여 구조 개선

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
-@import "tw-animate-css";
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/src/features/video/model/CreateSenderPeerConnect.ts
+++ b/app/src/features/video/model/CreateSenderPeerConnect.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { MutableRefObject } from 'react';
+
+interface CreateSenderPeerConnection {
+  socketRef: MutableRefObject<SocketIOClient.Socket | null>;
+  localStreamRef: MutableRefObject<MediaStream | null>;
+  sendPCRef: MutableRefObject<RTCPeerConnection | null>;
+  pc_config: RTCConfiguration;
+}
+
+export function CreateSenderPeerConnect({
+  socketRef,
+  localStreamRef,
+  sendPCRef,
+  pc_config,
+}: CreateSenderPeerConnection): RTCPeerConnection {
+  const pc = new RTCPeerConnection(pc_config);
+
+  pc.onicecandidate = (e) => {
+    if (!(e.candidate && socketRef?.current)) {
+      return;
+    }
+    console.log('sender PC onicecandidate');
+    socketRef.current.emit('senderCandidate', {
+      candidate: e.candidate,
+      senderSocketID: socketRef.current.id,
+    });
+  };
+
+  pc.oniceconnectionstatechange = (e) => {
+    console.log(e);
+  };
+
+  if (localStreamRef.current) {
+    console.log('add local stream');
+    localStreamRef.current.getTracks().forEach((track) => {
+      if (!localStreamRef.current) {
+        return;
+      }
+      pc.addTrack(track, localStreamRef.current);
+    });
+  } else {
+    console.log('no local stream');
+  }
+
+  sendPCRef.current = pc;
+  return pc;
+}

--- a/app/src/features/video/model/PeerConnect.tsx
+++ b/app/src/features/video/model/PeerConnect.tsx
@@ -4,6 +4,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import io from 'socket.io-client';
 import Video from '@/app/components';
 import { WebRTCUser } from '@/app/src/entities/meeting';
+import { CreateSenderPeerConnect } from './CreateSenderPeerConnect';
 
 const pc_config = {
   iceServers: [
@@ -138,39 +139,51 @@ const PeerConnect = () => {
     }
   }, []);
 
-  const createSenderPeerConnection = useCallback(() => {
-    const pc = new RTCPeerConnection(pc_config);
+  const createSenderPeerConnection = useCallback(
+    () =>
+      CreateSenderPeerConnect({
+        socketRef,
+        localStreamRef,
+        sendPCRef,
+        pc_config,
+      }),
+    [socketRef, localStreamRef, sendPCRef, pc_config]
+  );
 
-    pc.onicecandidate = (e) => {
-      if (!(e.candidate && socketRef.current)) {
-        return;
-      }
-      console.log('sender PC onicecandidate');
-      socketRef.current.emit('senderCandidate', {
-        candidate: e.candidate,
-        senderSocketID: socketRef.current.id,
-      });
-    };
-
-    pc.oniceconnectionstatechange = (e) => {
-      console.log(e);
-    };
-
-    if (localStreamRef.current) {
-      console.log('add local stream');
-      localStreamRef.current.getTracks().forEach((track) => {
-        if (!localStreamRef.current) {
-          return;
-        }
-        pc.addTrack(track, localStreamRef.current);
-      });
-    } else {
-      console.log('no local stream');
-    }
-
-    sendPCRef.current = pc;
-  }, []);
-
+  //
+  //const createSenderPeerConnection = useCallback(() => {
+  //  const pc = new RTCPeerConnection(pc_config);
+  //
+  //  pc.onicecandidate = (e) => {
+  //    if (!(e.candidate && socketRef.current)) {
+  //      return;
+  //    }
+  //    console.log('sender PC onicecandidate');
+  //    socketRef.current.emit('senderCandidate', {
+  //      candidate: e.candidate,
+  //      senderSocketID: socketRef.current.id,
+  //    });
+  //  };
+  //
+  //  pc.oniceconnectionstatechange = (e) => {
+  //    console.log(e);
+  //  };
+  //
+  //  if (localStreamRef.current) {
+  //    console.log('add local stream');
+  //    localStreamRef.current.getTracks().forEach((track) => {
+  //      if (!localStreamRef.current) {
+  //        return;
+  //      }
+  //      pc.addTrack(track, localStreamRef.current);
+  //    });
+  //  } else {
+  //    console.log('no local stream');
+  //  }
+  //
+  //  sendPCRef.current = pc;
+  //}, []);
+  //
   const getLocalStream = useCallback(async () => {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({


### PR DESCRIPTION
# Pull Request

## ➕ 이슈 번호
- #5 

<br/>


## 📄 요약
- 컴포넌트 내부에 있던 송신자용 WebRTC PeerConnection 생성 및 설정 로직을 `CreateSenderPeerConnect` 함수로 분리하였습니다.  

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<br/>

##  PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정

<br/>

## 👨‍🔧 변경사항
- `PeerConnect` 컴포넌트에서 송신자 PeerConnection 생성 로직 분리
- `CreateSenderPeerConnect` 함수 생성 및 외부 유틸 모듈로 이동
- 기존 `useCallback`으로 묶었던 `createSenderPeerConnection`이 함수 호출만 하도록 변경됨
<!--- 필요한 경우 중요한 변경사항에 대해 더 자세히 설명해주세요 -->

<br/>

## ➕ 이미지 첨부

<!--- UI 변경사항이 있는 경우 스크린샷이나 동영상을 첨부해주세요 -->

<br/>


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

<br/>

## 📢 특이사항
- 로직 자체는 변경하지 않았으며, 동작 방식은 기존과 동일합니다.
- 다른 로직들도 동일하게 분리하려고 합니다.

<!--- 리뷰어가 알아야 할 주의사항이나 특이점이 있다면 여기에 작성해주세요 -->
<br/>
